### PR TITLE
Fix organization name in organization page. ab#16683

### DIFF
--- a/src/CrystallineSociety/Client/Shared/Pages/OrganizationsSettingsPage.razor
+++ b/src/CrystallineSociety/Client/Shared/Pages/OrganizationsSettingsPage.razor
@@ -10,7 +10,7 @@
     <RowTemplate Context="Organization">
         <div @key="Organization.Code" style="@(Organizations.Count > 1 ? "border-bottom: 1px #8a8886 solid; padding: 5px 20px; margin: 10px;" : "")">
             <div style="margin-left:3%; display: inline-block;">
-                <p>Education Program Name: <strong>@Organization.Title</strong></p>
+                <p>Organization Name: <strong>@Organization.Title</strong></p>
                 <BitButton OnClick="WrapHandled(()=>HandelSyncAsync(Organization))">
                     Sync
                     <BitRollerLoading Size="@(IsSyncing ? 13 : 0)" />


### PR DESCRIPTION
The most significant change is the modification of the label for the organization's name in the user interface. The label was previously "Education Program Name", but it has been updated to "Organization Name" to provide more clarity and accuracy for users.

Changes:
1. Updated the label for the organization's name in the user interface from "Education Program Name" to "Organization Name". This change was made to improve the accuracy and clarity of the label for users. (Refer to the code changes in the user interface file)